### PR TITLE
7.0.10 紧急修复部分浏览器不兼容regexp lookbehind

### DIFF
--- a/dist/pxer-core.js
+++ b/dist/pxer-core.js
@@ -740,7 +740,7 @@ PxerHtmlParser.parseMediumHtml = function (_ref9) {
 
 PxerHtmlParser.REGEXP = {
     'getDate': /img\/((?:\d+\/){5}\d+)/,
-    'getInitData': /\{token:.*\}(?=\);)/
+    'getInitData': /(?<=\()\{token:.*\}(?=\);)/
 };
 
 PxerHtmlParser.HTMLParser = function (aHTMLString) {

--- a/dist/pxer-core.js
+++ b/dist/pxer-core.js
@@ -740,7 +740,7 @@ PxerHtmlParser.parseMediumHtml = function (_ref9) {
 
 PxerHtmlParser.REGEXP = {
     'getDate': /img\/((?:\d+\/){5}\d+)/,
-    'getInitData': /(?<=\()\{token:.*\}(?=\);)/
+    'getInitData': /\{token:.*\}(?=\);)/
 };
 
 PxerHtmlParser.HTMLParser = function (aHTMLString) {

--- a/src/app/class/PxerHtmlParser.class.js
+++ b/src/app/class/PxerHtmlParser.class.js
@@ -187,7 +187,7 @@ PxerHtmlParser.parseMediumHtml =function({task,dom,url,pw}){
 
 PxerHtmlParser.REGEXP ={
     'getDate':/img\/((?:\d+\/){5}\d+)/,
-    'getInitData':/(?<=\()\{token:.*\}(?=\);)/
+    'getInitData':/\{token:.*\}(?=\);)/
 };
 
 PxerHtmlParser.HTMLParser =function(aHTMLString){


### PR DESCRIPTION
无需lookbehind已经能够足够准确的parse信息