### PR TITLE
fix incorrect task count calculation

### DIFF
--- a/src/view/vm.js
+++ b/src/view/vm.js
@@ -67,7 +67,8 @@ afterLoad(function(){
                 return this.pxer.taskOption.limit ||this.pxer.worksNum;
             },
             taskCount(){
-                return Math.ceil(this.worksNum/20)+ +this.worksNum;
+                var pageWorkCount = this.pxer.pageType ==="search"? 40:20;
+                return Math.ceil(this.worksNum/pageWorkCount) +this.worksNum;
             },
             finishCount(){
                 if(this.state==='page'){


### PR DESCRIPTION
The original task count implementation returns incorrect values in search pages.  This PR provided a simple patch.