### PR TITLE
add bug report url in tampermonkey

### DIFF
--- a/build/user.jstpl.ejs
+++ b/build/user.jstpl.ejs
@@ -2,6 +2,7 @@
 // @name          Pxer<?=isDev?'-dev':''?>
 // @version       7
 // @namespace     https://github.com/pea3nut/Pxer
+// @supportURL    https://github.com/pea3nut/Pxer/issues/5
 // @author        花生PeA / eternal-flame-AD
 // @description   可能是目前最好用的P站收图工具
 // @grant         none

--- a/pxer-dev.user.js
+++ b/pxer-dev.user.js
@@ -5,6 +5,7 @@
 // @name          Pxer-dev
 // @version       7
 // @namespace     https://github.com/pea3nut/Pxer
+// @supportURL    https://github.com/pea3nut/Pxer/issues/5
 // @author        花生PeA / eternal-flame-AD
 // @description   可能是目前最好用的P站收图工具
 // @grant         none

--- a/pxer-master.user.js
+++ b/pxer-master.user.js
@@ -5,6 +5,7 @@
 // @name          Pxer
 // @version       7
 // @namespace     https://github.com/pea3nut/Pxer
+// @supportURL    https://github.com/pea3nut/Pxer/issues/5
 // @author        花生PeA / eternal-flame-AD
 // @description   可能是目前最好用的P站收图工具
 // @grant         none


### PR DESCRIPTION
Added a supportURL in Tampermonkey metadata so that users can access bug report URL from their Tampermonkey control panel.