### PR TITLE
sort tasklist by id (fix #133)

### DIFF
--- a/src/app/class/PxerApp.3.class.js
+++ b/src/app/class/PxerApp.3.class.js
@@ -204,8 +204,8 @@ class PxerApp extends PxerEvent{
             return false;
         };
         
-        // 任务按ID降序排列
-        tasks.sort((a,b)=>parseInt(b.id)-parseInt(a.id));
+        // 任务按ID降序排列(#133)
+        tasks.sort((a,b)=>Number(b.id)-Number(a.id));
 
         this.dispatch('executeWroksTask');
 

--- a/src/app/class/PxerApp.3.class.js
+++ b/src/app/class/PxerApp.3.class.js
@@ -203,6 +203,9 @@ class PxerApp extends PxerEvent{
             this.dispatch('error' ,'PxerApp.executeWroksTask: taskList is illegal');
             return false;
         };
+        
+        // 任务按ID降序排列
+        tasks.sort((a,b)=>parseInt(b.id)-parseInt(a.id));
 
         this.dispatch('executeWroksTask');
 


### PR DESCRIPTION
任务ID降序排列一次，防止 #133 提到的因为taskList顺序不稳定造成ID过滤异常